### PR TITLE
check if font, border and fill are available

### DIFF
--- a/R/excel_helpers.R
+++ b/R/excel_helpers.R
@@ -826,17 +826,39 @@ handle_cell_styles <- function(wb,
                                style = excel_output_style()){
     # Apply individual styles for each table part
     for (type in c("header", "box", "cat_col", "table")){
+
+        apply_font <- NULL
+        font_id <- NULL
+        if (paste0(type, "_font") %in% wb$styles_mgr$font$name) {
+            apply_font <- TRUE
+            font_id <- wb$styles_mgr$get_font_id(paste0(type, "_font"))
+        }
+
+        apply_border <- NULL
+        border_id <- NULL
+        if (paste0(type, "_borders") %in% wb$styles_mgr$border$name) {
+            apply_border <- TRUE
+            border_id <- wb$styles_mgr$get_border_id(paste0(type, "_borders"))
+        }
+
+        apply_fill <- NULL
+        fill_id <- NULL
+        if (paste0(type, "_fill") %in% wb$styles_mgr$fill$name) {
+            apply_fill <- TRUE
+            fill_id <- wb$styles_mgr$get_fill_id(paste0(type, "_fill"))
+        }
+
         wb$add_cell_style(dims         = ranges[[paste0(type, "_range")]],
                           horizontal   = style[[paste0(type, "_alignment")]],
                           vertical     = "center",
                           wrap_text    = style[[paste0(type, "_wrap")]],
                           indent       = style[[paste0(type, "_indent")]],
-                          apply_font   = TRUE,
-                          font_id      = wb$styles_mgr$get_font_id(paste0(type, "_font")),
-                          apply_border = TRUE,
-                          border_id    = wb$styles_mgr$get_border_id(paste0(type, "_borders")),
-                          apply_fill   = TRUE,
-                          fill_id      = wb$styles_mgr$get_fill_id(paste0(type, "_fill")))
+                          apply_font   = apply_font,
+                          font_id      = font_id,
+                          apply_border = apply_border,
+                          border_id    = border_id,
+                          apply_fill   = apply_fill,
+                          fill_id      = fill_id)
     }
 
     wb


### PR DESCRIPTION
before they are applied

in https://github.com/JanMarvin/openxlsx2/pull/1522 a warning was added for style id getter functions like `get_border_id()` if the style requested is non existent in the workbook. Previously `NULL` would have been returned without a warning. (Now `NULL` with a warning).

While I'm not 100% sure yet, if this will be in the release. I'd have to run a few tries with other packages, this caused warnings in `qol`. Nothing showed up in a revedep run. And in some cases `qol` creates styles that apply a style, but provide no style id (if the getter returns `NULL`). The suggested change should avoid this and make `qol` save for a possible warning in a new `openxlsx2` release.